### PR TITLE
Remove all references of Combine that SwiftUI internally exposes

### DIFF
--- a/NextToGo/Core/ConnectivityService.swift
+++ b/NextToGo/Core/ConnectivityService.swift
@@ -10,8 +10,9 @@ import Network
 
 // MARK: - ConnectivityService
 
+@Observable
 @MainActor
-final class ConnectivityService: ObservableObject {
+final class ConnectivityService {
 
     // MARK: Lifecycle
 
@@ -28,7 +29,7 @@ final class ConnectivityService: ObservableObject {
 
     static let shared = ConnectivityService()
 
-    @Published private(set) var isConnected = true
+    private(set) var isConnected = true
 
     // MARK: Private
 

--- a/NextToGo/Core/NextToGoApp.swift
+++ b/NextToGo/Core/NextToGoApp.swift
@@ -22,7 +22,9 @@ struct NextToGoApp: App {
 
 // MARK: - RootContentView
 
-/// This view is used in case SwiftData feature would like to be enabled and by default this is turned off since it was not a feature specified anywhere. Uncomment all TODO: SwiftData lines
+// This view is used in case SwiftData feature would like to be enabled
+// and by default this is turned off since it was not a feature specified anywhere.
+// Uncomment all TODO: SwiftData lines
 // TODO: SwiftData
 struct RootContentView: View {
 //    @Environment(\.modelContext) private var modelContext

--- a/NextToGo/Presentation/RaceListView/RaceListView.swift
+++ b/NextToGo/Presentation/RaceListView/RaceListView.swift
@@ -11,7 +11,7 @@ struct RaceListView: View {
 
     // MARK: Internal
 
-    @StateObject var viewModel: RaceListViewModel
+    @State var viewModel: RaceListViewModel
 
     var body: some View {
         NavigationView {

--- a/NextToGo/Presentation/RaceListView/RaceListViewModel.swift
+++ b/NextToGo/Presentation/RaceListView/RaceListViewModel.swift
@@ -8,8 +8,9 @@
 import Foundation
 import SwiftUI
 
+@Observable
 @MainActor
-class RaceListViewModel: ObservableObject {
+final class RaceListViewModel {
 
     // MARK: Lifecycle
 
@@ -29,15 +30,17 @@ class RaceListViewModel: ObservableObject {
     }
 
     deinit {
-        autoRefreshTask?.cancel()
+        Task { @MainActor [weak self] in
+            self?.autoRefreshTask?.cancel()
+        }
     }
 
     // MARK: Internal
 
-    @Published private(set) var races: [Race] = []
-    @Published var selectedCategories: Set<RaceCategory> = []
-    @Published var errorMessage: String?
-    @Published var isLoading = false
+    private(set) var races: [Race] = []
+    var selectedCategories: Set<RaceCategory> = []
+    var errorMessage: String?
+    var isLoading = false
 
     var autoRefreshTask: Task<Void, Never>?
 


### PR DESCRIPTION
- Remove all observable objects, state object and published uses
- Migrate over to @Observable and @State
- Extra safety check to ensure deinit cancels autoRefreshTask 